### PR TITLE
Add auto-refresh, per-instance autostart, image/video/slideshow input…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,409 @@
+# Vingester &mdash; Ingest Web Contents as Video Streams
 
 <img src="https://raw.githubusercontent.com/rse/vingester/master/vingester-icon.png" width="150" align="right" alt=""/>
 
-[Vingester](https://vingester.app)
-==================================
+**Vingester** (Video Ingester) is an [Electron](https://www.electronjs.org/)-based desktop application for Windows, macOS and Linux that runs one or more headless Chromium browser instances and streams their rendered output as [NDI&reg;](https://ndi.video/) video streams (or [FFmpeg](https://ffmpeg.org/)-encoded files/streams). It also accepts still images, videos and slideshows as input, converting them directly to NDI output.
 
-**Ingest Web Contents as Video Streams**
+Licensed under [GPL 3.0](https://spdx.org/licenses/GPL-3.0-only).
 
-About
------
+---
 
-**Vingester** (**V**ideo **ingester**) is a small
-[Electron](https://www.electronjs.org/)-based desktop application
-for use under Windows, macOS or Linux to run multiple
-[Chromium](https://www.chromium.org/)-based Web browser instances and
-ingesting their rendered Web Contents as screen/window-captured or
-[NDI](https://www.ndi.tv/)-multicasted or [FFmpeg](https://ffmpeg.org)-based
-video streams for further use in local or remote video mixing applications or
-for local recording.
+## Table of Contents
 
-Sneak Preview
--------------
+1. [Features](#features)
+2. [Installation / Build Guide](#installation--build-guide)
+3. [Command-Line Flags](#command-line-flags)
+4. [Instance Configuration Reference](#instance-configuration-reference)
+5. [Input Types](#input-types)
+6. [Auto-Refresh and Auto-Start](#auto-refresh-and-auto-start)
+7. [REST API](#rest-api)
+8. [Web UI Dashboard](#web-ui-dashboard)
+9. [Settings Export and Import (YAML)](#settings-export-and-import-yaml)
+10. [Windows Service (Auto-Start on Boot)](#windows-service-auto-start-on-boot)
+11. [Linux/macOS Service](#linuxmacos-service)
+12. [Stability Notes](#stability-notes)
+13. [Sample Configurations](#sample-configurations)
+14. [Credits](#credits)
 
-![Vingester Screenshot](vingester-screenshot.png)
+---
 
-Documentation
--------------
+## Features
 
-See the [Vingester Guide](https://vingester.app/guide/) for detailed
-documentation on **Vingester**.
+- **NDI Output**: Streams web content as NDI video over LAN for use in OBS Studio, vMix, etc.
+- **FFmpeg Output**: Record to file (MKV, MP4) or stream (MPEG-TS/UDP, RTP, RTMP/FLV).
+- **Image/Video Input**: Use a still image or looping video file as an NDI source.
+- **Slideshow Input**: Cycle through multiple images/videos with fade transitions.
+- **Auto-Refresh**: Each instance can reload its content on a configurable timer.
+- **Auto-Start per Instance**: Mark individual instances to start automatically on launch.
+- **Web UI Dashboard**: Browser-based management interface with media upload and live status.
+- **REST API**: HTTP API for remote control via Stream Deck, Companion, etc.
+- **CSS/JS Patching**: Inject custom CSS and JavaScript into any web page.
+- **Adaptive Frame Rate**: Reduce FPS automatically based on NDI tally state.
+- **Settings Export/Import**: Full YAML-based configuration portability.
+- **Windows Service**: Install as a Windows service with crash-restart via NSSM.
 
-Copyright & License
--------------------
+---
 
-Copyright &copy; 2021-2022 [Dr. Ralf S. Engelschall](mailto:rse@engelschall.com)<br/>
-Licensed under [GPL 3.0](https://spdx.org/licenses/GPL-3.0-only)
+## Installation / Build Guide
 
+### Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [Node.js](https://nodejs.org/) | 16 or 18 LTS | JavaScript runtime |
+| [npm](https://www.npmjs.com/) | 8+ | Package manager |
+| [Git](https://git-scm.com/) | any | Source control |
+| NDI SDK (Windows/macOS) | 5+ | NDI runtime for video output |
+
+> **Linux note:** NDI SDK is not officially supported on Linux. The app will still build and run but NDI output will be unavailable.
+
+### Steps
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/rse/vingester.git
+cd vingester
+
+# 2. Install dependencies
+npm install
+
+# 3a. Run in development mode (hot-reload)
+npm start
+
+# 3b. Run in debug mode (extra logging + DevTools auto-opened)
+DEBUG=2 npm start
+
+# 3c. Run production build directly (no hot-reload)
+npm run start-prod
+
+# 4. Package a distributable build
+npm run package
+#    Output: dist/win-unpacked/Vingester.exe   (Windows)
+#            dist/mac/Vingester.app            (macOS)
+#            dist/Vingester-<ver>.AppImage      (Linux)
+
+# 5. Clean build artifacts
+npm run clean       # removes dist/
+npm run distclean   # removes dist/ and node_modules/
+```
+
+### Platform Notes
+
+**Windows**: NDI SDK must be installed first. Download from [ndi.video](https://ndi.video/tools/ndi-sdk/).
+
+**macOS**: NDI SDK required. App may need to be codesigned for distribution.
+
+**Linux**: NDI output unavailable. FFmpeg output still works.
+
+---
+
+## Command-Line Flags
+
+These flags are passed directly to the Vingester executable (or to `electron .` during development).
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--profile=<name>` | string | (none) | Use a named user-data profile. Can be a simple name (e.g. `production`) which appends to the default userData path, or an absolute directory path. Allows multiple independent Vingester instances on the same machine. |
+| `--config=<file>` | string | (none) | Path to a YAML config file. Auto-imported on startup; auto-exported on graceful shutdown. Enables fully stateless/portable operation. |
+| `--tag=<text>` | string | (none) | Display a text tag in the control window header to identify this instance. |
+| `--minimize` | flag | false | Start the control window minimized to the taskbar. |
+| `--autostart` | flag | false | Automatically start all valid browser instances 2 seconds after launch. Equivalent to clicking "START ALL" on launch. |
+
+### Usage Examples
+
+```bash
+# Development with profile and config file
+electron . --profile=studio --config=/home/user/studio.yaml
+
+# Production binary, minimized, all auto-started
+Vingester.exe --minimize --autostart --tag="Studio A"
+
+# Portable operation (config file as single source of truth)
+Vingester.exe --config=C:\vingester\config.yaml --autostart
+
+# Multiple instances on the same machine using separate profiles
+Vingester.exe --profile=cam1 --config=cam1.yaml --autostart
+Vingester.exe --profile=cam2 --config=cam2.yaml --autostart
+```
+
+---
+
+## Instance Configuration Reference
+
+Each browser instance has the following configuration fields. Long names are used in YAML export/import files.
+
+### Browser Settings
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `BrowserTitle` | `t` | string | `""` | **Required.** Name of the browser instance and NDI stream. |
+| `BrowserInfo` | `i` | string | `""` | User-defined notes. Not used internally. |
+| `BrowserWidth` | `w` | number | `1280` | Canvas width in pixels (854=480p, 1280=720p, 1920=1080p). |
+| `BrowserHeight` | `h` | number | `720` | Canvas height in pixels (480, 720, 1080). |
+| `BrowserColor` | `c` | string | `"transparent"` | Background color: `transparent` or `#RRGGBB`. |
+| `BrowserZoom` | `z` | number | `1.0` | Browser zoom level. |
+| `BrowserTrust` | `H` | boolean | `false` | Trust unknown SSL/TLS certificates. |
+| `BrowserNodeAPI` | `I` | boolean | `false` | Enable Node.js API in browser context (security risk). |
+| `BrowserOBSDOM` | `B` | boolean | `false` | Emulate OBS Studio Browser Source DOM events. |
+| `BrowserPersist` | `S` | boolean | `false` | Persist browser session (cookies, storage) across restarts. |
+
+### Auto-Refresh and Auto-Start
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `AutoRefreshEnabled` | `ar` | boolean | `false` | Enable automatic periodic page reload. |
+| `AutoRefreshInterval` | `ai` | number | `300` | Seconds between reloads (minimum: 5). |
+| `InstanceAutoStart` | `as` | boolean | `false` | Start this instance automatically when Vingester launches. |
+
+### Input Settings
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `InputType` | `it` | string | `"url"` | Input type: `url`, `image`, `video`, or `slideshow`. |
+| `InputURL` | `u` | string | `""` | URL to load when `InputType` is `url`. |
+| `InputFiles` | `if` | string | `""` | File path(s) for image/video/slideshow. Multiple paths separated by newlines for slideshows. |
+| `SlideshowInterval` | `si` | number | `5` | Seconds each slide is shown before advancing. |
+| `SlideshowFade` | `sf` | number | `1` | Duration of crossfade transition between slides (seconds). |
+
+### Patch Settings
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `PatchDelay` | `k` | number | `0` | Milliseconds to wait after page load before injecting patches. |
+| `PatchFrame` | `j` | string | `""` | URL regex to select a sub-frame for patching. Empty = main frame. |
+| `PatchStyleType` | `g` | string | `"inline"` | CSS source: `inline` (code in field) or `file` (path in field). |
+| `PatchStyleCode` | `q` | string | `""` | CSS code or file path to inject. |
+| `PatchScriptType` | `G` | string | `"inline"` | JS source: `inline` or `file`. |
+| `PatchScriptCode` | `Q` | string | `""` | JavaScript code or file path to inject. |
+
+### NDI/FFmpeg Output Settings
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `Output2Enabled` | `N` | boolean | `false` | **Required.** Enable NDI/FFmpeg output. |
+| `Output2VideoFrameRate` | `f` | number | `30` | Capture FPS (common: 24, 30, 48, 60). Use 0 for audio-only. |
+| `Output2VideoAdaptive` | `a` | boolean | `false` | Reduce FPS based on NDI tally (saves CPU when idle). |
+| `Output2VideoDelay` | `O` | number | `0` | Video delay in milliseconds. |
+| `Output2AudioSampleRate` | `r` | number | `48000` | Sample rate: 8000, 12000, 16000, 24000, or 48000 Hz. |
+| `Output2AudioChannels` | `C` | number | `2` | Audio channels (0=video-only, 1=mono, 2=stereo). |
+| `Output2AudioDelay` | `o` | number | `0` | Audio delay in milliseconds. |
+| `Output2SinkNDIEnabled` | `n` | boolean | `true` | Send output as NDI stream. |
+| `Output2SinkNDIAlpha` | `v` | boolean | `true` | Include alpha channel in NDI (for keying). |
+| `Output2SinkNDITallyReload` | `l` | boolean | `false` | Reload page when NDI tally enters preview or program. |
+| `Output2SinkFFmpegEnabled` | `m` | boolean | `false` | Pass output to FFmpeg. |
+| `Output2SinkFFmpegMode` | `R` | string | `"vbr"` | Quality mode: `vbr` (recording), `abr`, or `cbr` (streaming). |
+| `Output2SinkFFmpegFormat` | `F` | string | `"matroska"` | Format: `matroska`, `mp4`, `mpegts`, `rtp`, `flv`. |
+| `Output2SinkFFmpegOptions` | `M` | string | `""` | FFmpeg CLI arguments (output filename or stream URL). |
+
+### UI Settings
+
+| YAML Name | Short | Type | Default | Description |
+|-----------|-------|------|---------|-------------|
+| `PreviewEnabled` | `P` | boolean | `false` | Show thumbnail preview (160x90) in the control UI. |
+| `ConsoleEnabled` | `T` | boolean | `false` | Show browser console messages in the control UI. |
+| `DevToolsEnabled` | `E` | boolean | `false` | Open Chrome DevTools for this instance. |
+| `Collapsed` | `_` | boolean | `false` | Collapse this entry in the UI. |
+
+---
+
+## Input Types
+
+### URL (default)
+
+Standard web browser mode. Enter any `http://`, `https://`, or `file://` URL.
+
+```yaml
+InputType: "url"
+InputURL:  "https://example.com/my-overlay"
+```
+
+### Image
+
+Display a single still image file. Supports PNG, JPG, GIF, WEBP, BMP, SVG. The image fills the canvas with letterboxing. Transparent PNGs work with `BrowserColor: "transparent"`.
+
+```yaml
+InputType:  "image"
+InputFiles: "C:\\Media\\logo.png"
+```
+
+### Video
+
+Loop a video file. Supports MP4, WebM, OGG, MOV.
+
+```yaml
+InputType:  "video"
+InputFiles: "C:\\Media\\background.mp4"
+```
+
+### Slideshow
+
+Cycle through multiple images and/or videos with CSS fade transitions. Paths are separated by newlines.
+
+```yaml
+InputType:         "slideshow"
+InputFiles:        "C:\\Media\\slide1.png\nC:\\Media\\slide2.jpg\nC:\\Media\\clip.mp4"
+SlideshowInterval: 8
+SlideshowFade:     1.5
+```
+
+Under the hood, Vingester generates a self-contained HTML/JS page with CSS `opacity` transitions and loads it via a `file://` URL. The existing browser pipeline processes it identically to any other web content — no special code paths needed.
+
+---
+
+## Auto-Refresh and Auto-Start
+
+### Auto-Refresh
+
+When `AutoRefreshEnabled` is `true`, Vingester reloads the page every `AutoRefreshInterval` seconds (minimum 5s). Useful for recovering from disconnections or keeping live data current.
+
+### Auto-Start per Instance
+
+When `InstanceAutoStart` is `true`, that instance starts automatically 2 seconds after the control UI loads. Independent of the `--autostart` CLI flag (which starts all instances). You can combine both.
+
+---
+
+## REST API
+
+The REST API runs on port 7211 by default. Enable it in the control UI (globe icon).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | JSON array of all instance titles |
+| `GET/POST` | `/all/start` | Start all instances |
+| `GET/POST` | `/all/reload` | Reload all instances |
+| `GET/POST` | `/all/stop` | Stop all instances |
+| `GET/POST` | `/{title}/start` | Start instance by title |
+| `GET/POST` | `/{title}/reload` | Reload instance by title |
+| `GET/POST` | `/{title}/stop` | Stop instance by title |
+| `GET/POST` | `/{title}/clear` | Clear persistent session for instance |
+
+```bash
+curl http://127.0.0.1:7211/
+curl http://127.0.0.1:7211/all/start
+curl "http://127.0.0.1:7211/My-Camera/stop"
+```
+
+---
+
+## Web UI Dashboard
+
+The Web UI runs on port 7212 by default. Enable it in the control UI (monitor icon). Open `http://127.0.0.1:7212/` in any browser.
+
+**Instances panel**: Live status, start/stop/reload per instance, auto-refreshes every 5 seconds.
+
+**Media Manager panel**: Upload images and videos (drag-and-drop). View and delete files. Uploaded files are stored in `{userData}/Media/`.
+
+Allowed upload types: PNG, JPG, GIF, WEBP, BMP, SVG, MP4, WEBM, OGG, MOV (max 500 MB).
+
+---
+
+## Settings Export and Import (YAML)
+
+- Click **EXPORT** to save all instances to a `.yaml` file.
+- Click **IMPORT** to load instances from a `.yaml` file (replaces current config).
+- Use `--config=<file>` for automatic export/import on startup/shutdown.
+
+**Backward compatibility**: Old YAML files with `Output1*` fields (frameless window, removed in this fork) will have those fields silently ignored. All other settings are preserved. Missing new fields default to safe values.
+
+---
+
+## Windows Service (Auto-Start on Boot)
+
+Use the included installer script with [NSSM](https://nssm.cc/).
+
+### Setup
+
+1. Build Vingester: `npm run package`
+2. Download NSSM from [https://nssm.cc/download](https://nssm.cc/download), extract to `C:\nssm\`
+3. Open Command Prompt as Administrator:
+
+```cmd
+cd C:\path\to\vingester
+node installer\install-service.js install --name Vingester --args "--autostart --config C:\vingester\config.yaml"
+```
+
+### Commands
+
+```cmd
+node installer\install-service.js uninstall --name Vingester
+node installer\install-service.js start     --name Vingester
+node installer\install-service.js stop      --name Vingester
+node installer\install-service.js status    --name Vingester
+```
+
+NSSM configures automatic crash recovery (restart after 5 seconds) and logs to `./logs/`.
+
+---
+
+## Linux/macOS Service
+
+### Linux (systemd)
+
+Create `/etc/systemd/system/vingester.service`:
+
+```ini
+[Unit]
+Description=Vingester NDI Browser Ingest
+After=network.target
+
+[Service]
+Type=simple
+User=youruser
+Environment=DISPLAY=:0
+ExecStart=/opt/vingester/Vingester.AppImage --no-sandbox --autostart --config=/etc/vingester/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now vingester
+```
+
+For headless servers, use a virtual display: `Xvfb :99 -screen 0 1280x720x24 &` and `DISPLAY=:99`.
+
+### macOS (launchd)
+
+Create `~/Library/LaunchAgents/com.vingester.plist` with `RunAtLoad` and `KeepAlive` set to true, pointing to the `Vingester.app` binary with `--autostart --config /path/to/config.yaml`.
+
+---
+
+## Stability Notes
+
+Fixes applied in this fork:
+
+1. **IPC listener memory leak**: `browser-worker-stopped` now uses `ipcMain.once()` preventing listener accumulation.
+2. **Auto-refresh timer cleanup**: Timer is properly cleared on stop and recreated on reconfigure.
+3. **Generated HTML cleanup**: Temporary HTML files for media inputs are deleted when the instance stops.
+4. **Backward-compatible settings**: All new fields have safe defaults; unknown fields are pruned; old configs always import cleanly.
+
+---
+
+## Sample Configurations
+
+| File | Description |
+|------|-------------|
+| `cfg-sample-test.yaml` | Vingester test page |
+| `cfg-sample-expert.yaml` | Expert series (4 YouTube videos) |
+| `cfg-sample-fps.yaml` | FPS demo |
+| `cfg-sample-jitsi.yaml` | Jitsi Meet video conferencing |
+| `cfg-sample-vdon.yaml` | VDO.Ninja remote streaming |
+
+Samples are automatically copied to `{userData}/Configurations/` on startup.
+
+---
+
+## Credits
+
+- **Original Author**: Dr. Ralf S. Engelschall &lt;rse@engelschall.com&gt;
+- **NDI**: NewTek, Inc. / Vizrt Group
+- **FFmpeg**: Fabrice Bellard
+- **Electron**: GitHub, Inc.
+- **Chromium / V8**: Google LLC
+- **Node.js**: OpenJS Foundation
+- **Vue.js**: Evan You
+
+License: [GPL 3.0](https://spdx.org/licenses/GPL-3.0-only)

--- a/installer/install-service.js
+++ b/installer/install-service.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/*
+**  Vingester Windows Service Installer
+**  Copyright (c) 2021-2025 Dr. Ralf S. Engelschall <rse@engelschall.com>
+**  Licensed under GPL 3.0 <https://spdx.org/licenses/GPL-3.0-only>
+**
+**  Usage:
+**    node install-service.js install   [--name <svcName>] [--args "<extra args>"]
+**    node install-service.js uninstall [--name <svcName>]
+**    node install-service.js start     [--name <svcName>]
+**    node install-service.js stop      [--name <svcName>]
+**    node install-service.js status    [--name <svcName>]
+**
+**  Requirements:
+**    - Windows OS
+**    - NSSM (Non-Sucking Service Manager) in PATH, OR
+**      installed via: https://nssm.cc/download
+**    - Run as Administrator
+**
+**  Example (from repo root, run as Administrator):
+**    node installer\install-service.js install --name VingesterNDI --args "--autostart --config C:\vingester\config.yaml"
+*/
+
+const os      = require("os")
+const fs      = require("fs")
+const path    = require("path")
+const { execSync, spawnSync } = require("child_process")
+
+/*  parse simple CLI args  */
+const args    = process.argv.slice(2)
+const action  = args[0]
+let svcName   = "Vingester"
+let extraArgs = "--autostart"
+
+for (let i = 1; i < args.length; i++) {
+    if (args[i] === "--name" && args[i + 1])  { svcName   = args[++i]; continue }
+    if (args[i] === "--args" && args[i + 1])  { extraArgs = args[++i]; continue }
+}
+
+/*  check platform  */
+if (os.platform() !== "win32") {
+    console.error("ERROR: This script is Windows-only.")
+    console.error("For Linux/macOS, use systemd or launchd instead.")
+    console.error("See the README.md for instructions.")
+    process.exit(1)
+}
+
+/*  find the Vingester executable  */
+const appRoot = path.resolve(__dirname, "..")
+const possibleExes = [
+    path.join(appRoot, "dist", "win-unpacked", "Vingester.exe"),
+    path.join(appRoot, "dist", "Vingester.exe"),
+    path.join(appRoot, "Vingester.exe")
+]
+let exePath = null
+for (const p of possibleExes) {
+    if (fs.existsSync(p)) {
+        exePath = p
+        break
+    }
+}
+if (!exePath && action === "install") {
+    console.error("ERROR: Could not find Vingester.exe.")
+    console.error("Please build the application first: npm run package")
+    console.error("Or specify the path in install-service.js.")
+    process.exit(1)
+}
+
+/*  find NSSM  */
+function findNSSM () {
+    try {
+        execSync("nssm version", { stdio: "pipe" })
+        return "nssm"
+    }
+    catch (e) {}
+    /*  check common install locations  */
+    const candidates = [
+        "C:\\nssm\\nssm.exe",
+        "C:\\nssm\\win64\\nssm.exe",
+        "C:\\Program Files\\nssm\\nssm.exe",
+        "C:\\tools\\nssm\\nssm.exe"
+    ]
+    for (const c of candidates) {
+        if (fs.existsSync(c)) return `"${c}"`
+    }
+    return null
+}
+
+function run (cmd, ignoreError) {
+    console.log(`  > ${cmd}`)
+    const result = spawnSync(cmd, { shell: true, stdio: "inherit" })
+    if (result.status !== 0 && !ignoreError) {
+        console.error(`ERROR: command failed with exit code ${result.status}`)
+        process.exit(result.status)
+    }
+}
+
+/*  print usage  */
+if (!action || action === "--help" || action === "-h") {
+    console.log("Vingester Windows Service Installer")
+    console.log("")
+    console.log("Usage:")
+    console.log("  node install-service.js install   [--name <name>] [--args \"<args>\"]")
+    console.log("  node install-service.js uninstall [--name <name>]")
+    console.log("  node install-service.js start     [--name <name>]")
+    console.log("  node install-service.js stop      [--name <name>]")
+    console.log("  node install-service.js status    [--name <name>]")
+    console.log("")
+    console.log("Options:")
+    console.log("  --name <name>   Service name (default: Vingester)")
+    console.log("  --args <args>   Extra arguments passed to Vingester.exe")
+    console.log("                  (default: --autostart)")
+    console.log("")
+    console.log("Recommended extra args:")
+    console.log("  --autostart                     Auto-start all NDI instances")
+    console.log("  --config C:\\path\\config.yaml    Load+save a YAML config file")
+    console.log("  --minimize                       Start minimized")
+    console.log("  --profile myprofile             Use a named profile")
+    console.log("")
+    console.log("Example:")
+    console.log('  node install-service.js install --name VingesterNDI --args "--autostart --config C:\\vingester\\config.yaml"')
+    process.exit(0)
+}
+
+const nssm = findNSSM()
+
+if (action === "install") {
+    if (!nssm) {
+        console.error("ERROR: NSSM not found in PATH or common locations.")
+        console.error("")
+        console.error("Please install NSSM:")
+        console.error("  1. Download from https://nssm.cc/download")
+        console.error("  2. Extract and place nssm.exe in C:\\nssm\\ or add to PATH")
+        console.error("  3. Re-run this installer as Administrator")
+        process.exit(1)
+    }
+    console.log(`Installing Windows service: "${svcName}"`)
+    console.log(`  Executable: ${exePath}`)
+    console.log(`  Arguments:  ${extraArgs}`)
+    console.log("")
+
+    /*  install the service  */
+    run(`${nssm} install "${svcName}" "${exePath}"`)
+    run(`${nssm} set "${svcName}" AppParameters "${extraArgs}"`)
+
+    /*  configure crash recovery: restart on failure  */
+    run(`${nssm} set "${svcName}" AppExit Default Restart`)
+    run(`${nssm} set "${svcName}" AppRestartDelay 5000`)
+
+    /*  configure startup type: automatic  */
+    run(`${nssm} set "${svcName}" Start SERVICE_AUTO_START`)
+
+    /*  configure display name and description  */
+    run(`${nssm} set "${svcName}" DisplayName "Vingester NDI Browser Ingest"`)
+    run(`${nssm} set "${svcName}" Description "Ingests web content as NDI video streams."`)
+
+    /*  configure log files  */
+    const logDir = path.join(appRoot, "logs")
+    if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true })
+    run(`${nssm} set "${svcName}" AppStdout "${path.join(logDir, "service-stdout.log")}"`)
+    run(`${nssm} set "${svcName}" AppStderr "${path.join(logDir, "service-stderr.log")}"`)
+    run(`${nssm} set "${svcName}" AppRotateFiles 1`)
+    run(`${nssm} set "${svcName}" AppRotateBytes 10485760`)  /*  10 MB  */
+
+    /*  start the service  */
+    run(`${nssm} start "${svcName}"`)
+
+    console.log("")
+    console.log(`SUCCESS: Service "${svcName}" installed and started.`)
+    console.log(`Use "sc query ${svcName}" to check status.`)
+    console.log(`Use "node install-service.js uninstall" to remove.`)
+}
+else if (action === "uninstall") {
+    if (!nssm) {
+        console.error("ERROR: NSSM not found.")
+        process.exit(1)
+    }
+    console.log(`Uninstalling Windows service: "${svcName}"`)
+    run(`${nssm} stop "${svcName}"`, true)
+    run(`${nssm} remove "${svcName}" confirm`)
+    console.log(`SUCCESS: Service "${svcName}" removed.`)
+}
+else if (action === "start") {
+    if (!nssm) {
+        run(`sc start "${svcName}"`)
+    }
+    else {
+        run(`${nssm} start "${svcName}"`)
+    }
+}
+else if (action === "stop") {
+    if (!nssm) {
+        run(`sc stop "${svcName}"`)
+    }
+    else {
+        run(`${nssm} stop "${svcName}"`)
+    }
+}
+else if (action === "status") {
+    run(`sc query "${svcName}"`)
+}
+else {
+    console.error(`Unknown action: "${action}". Use --help for usage.`)
+    process.exit(1)
+}

--- a/vingester-control.html
+++ b/vingester-control.html
@@ -61,6 +61,13 @@
                                     <span class="icon"><i class="fas fa-globe" data-fa-transform="shrink-7"></i></span>
                                 </span>
                             </div>
+                            <div v-tippy="{ placement: 'bottom', content: 'Click to show/hide the<br/>Web UI dialog.' }"
+                                v-on:click="modalToggle('webui')">
+                                <span class="icon-stack">
+                                    <span class="icon"><i class="fas fa-circle"></i></span>
+                                    <span class="icon"><i class="fas fa-desktop" data-fa-transform="shrink-7"></i></span>
+                                </span>
+                            </div>
                             <div v-tippy="{ placement: 'bottom', content: 'Click to show/hide the<br/>application error messages.' }"
                                 v-on:click="modalToggle('messages')">
                                 <span class="icon-stack">
@@ -148,7 +155,7 @@
                                     </div>
                                 </div>
                                 <div class="field field-gpu" v-on:click="toggleGPU"
-                                    v-tippy="{ placement: 'bottom', content: (gpu ? 'Disable the currently enabled' : 'Enable the currently disabled') + '<br/>GPU hardware acceleration.<br/>Enable for Frameless mode.<br/>Disable for Headless mode.' }">
+                                    v-tippy="{ placement: 'bottom', content: (gpu ? 'Disable the currently enabled' : 'Enable the currently disabled') + '<br/>GPU hardware acceleration.<br/>Disable for NDI headless mode (recommended).<br/>Enable only if rendering requires GPU.' }">
                                     <div class="input-button">
                                         <span v-show="gpu"><span class="icon"><i class="fas fa-check-circle"></i></span>&nbsp;&nbsp;<span class="label">GPU:</span> YES</span>
                                         <span v-show="!gpu"><span class="icon"><i class="fas fa-times-circle"></i></span>&nbsp;&nbsp;<span class="label">GPU:</span> NO</span>
@@ -221,6 +228,48 @@
                         <p>
                         The <tt><i>browser</i></tt> parameter is the <b>BROWSER / Title</b> of the browser (or <tt>all</tt> for all
                         browsers) and the <tt><i>command</i></tt> parameter is <tt>start</tt>, <tt>reload</tt> or <tt>stop</tt>.
+                        </p>
+                    </div>
+                </div>
+                <div class="ui-modal-webui" v-show="modal === 'webui'">
+                    <div class="form">
+                        <div class="label label-webui">Web UI:</div>
+                        <div class="field field-webui"
+                            v-tippy="{ placement: 'top', content: 'Click to ' + (webuiEnabled ? 'disable' : 'enable') + ' the Web UI dashboard<br/>for browser management and media uploads.' }">
+                            <div class="toggle" v-on:click="toggleWebUI()">
+                                <div class="toggle-option" v-bind:class="{ selected:  webuiEnabled }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
+                                <div class="toggle-option" v-bind:class="{ selected: !webuiEnabled }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
+                            </div>
+                        </div>
+                        <div class="label label-webui-addr">IP Address:</div>
+                        <div class="field field-webui-addr"
+                            v-tippy="{ placement: 'top', content: 'IP address to listen on<br/>(Use 0.0.0.0 for any address).' }">
+                            <input type="text" v-model="webuiAddr"
+                                v-bind:class="{ disabled: webuiEnabled }"
+                                v-bind:disabled="webuiEnabled">
+                        </div>
+                        <div class="label label-webui-port">TCP Port:</div>
+                        <div class="field field-webui-port"
+                            v-tippy="{ placement: 'top', content: 'TCP port to listen on.' }">
+                            <input type="text" v-model="webuiPort"
+                                v-bind:class="{ disabled: webuiEnabled }"
+                                v-bind:disabled="webuiEnabled">
+                        </div>
+                    </div>
+                    <div class="about">
+                        If enabled, <b>Vingester</b> serves a <i>Web UI Dashboard</i> on the configured
+                        address and port. Open it in any browser for a live overview of all instances,
+                        start/stop/reload controls, and a <i>Media Manager</i> for uploading images
+                        and videos used by image, video and slideshow input types.
+                        <p>
+                        Access the Web UI at:
+                        </p>
+                        <div class="url">
+                            <tt>http://{{ webuiAddr }}:{{ webuiPort }}/</tt>
+                        </div>
+                        <p>
+                        The REST API for the Web UI is available at <tt>/api/instances</tt>,
+                        <tt>/api/all/{command}</tt> and <tt>/api/media</tt>.
                         </p>
                     </div>
                 </div>
@@ -593,6 +642,19 @@
                                     </div>
                                     <div class="row" v-show="!browser._">
                                         <div class="group">INPUT:</div>
+                                        <div class="label">Type:</div>
+                                        <div class="field"
+                                            v-tippy="{ placement: 'top', content: 'Select input source type: URL for web content,<br/>Image for a still image file, Video for a looping video,<br/>or Slideshow for multiple images with fade transitions.' }">
+                                            <div class="toggle" v-on:click="toggle(browser, 'it', [ 'url', 'image', 'video', 'slideshow' ])">
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.it === 'url'       }"><span class="icon"><i class="fas fa-globe"></i></span> URL</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.it === 'image'     }"><span class="icon"><i class="fas fa-image"></i></span> Image</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.it === 'video'     }"><span class="icon"><i class="fas fa-film"></i></span> Video</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.it === 'slideshow' }"><span class="icon"><i class="fas fa-images"></i></span> Slideshow</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row" v-show="!browser._ && browser.it === 'url'">
+                                        <div class="group"></div>
                                         <div class="label label-url">URL:</div>
                                         <div class="field field-url"
                                             v-tippy="{ placement: 'top', content: 'Uniform Resource Locator (URL)<br/>of Web Content to render.' }">
@@ -600,6 +662,62 @@
                                                 v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.u }"
                                                 v-bind:disabled="running[browser.id]">
                                         </div>
+                                    </div>
+                                    <div class="row" v-show="!browser._ && (browser.it === 'image' || browser.it === 'video')">
+                                        <div class="group"></div>
+                                        <div class="label">File:</div>
+                                        <div class="field field-url"
+                                            v-tippy="{ placement: 'top', content: 'Path to the image or video file to display.' }">
+                                            <input type="text" v-model="browser.if" v-on:keyup="changed(browser)"
+                                                v-bind:class="{ disabled: running[browser.id] }"
+                                                v-bind:disabled="running[browser.id]">
+                                        </div>
+                                        <div class="field field-reload"
+                                            v-tippy="{ placement: 'top', content: 'Browse for a media file.' }"
+                                            v-bind:class="{ disabled: running[browser.id] }"
+                                            v-on:click="selectMediaFiles(browser, false)">
+                                            <div class="input-button">
+                                                <span class="icon"><i class="fas fa-folder-open"></i></span> Browse
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row" v-show="!browser._ && browser.it === 'slideshow'">
+                                        <div class="group"></div>
+                                        <div class="label">Files:</div>
+                                        <div class="field field-url"
+                                            v-tippy="{ placement: 'top', content: 'Paths to image/video files for the slideshow,<br/>one per line.' }">
+                                            <input type="text" v-model="browser.if" v-on:keyup="changed(browser)"
+                                                v-bind:class="{ disabled: running[browser.id] }"
+                                                v-bind:disabled="running[browser.id]"
+                                                placeholder="(one file path per line)">
+                                        </div>
+                                        <div class="field field-reload"
+                                            v-tippy="{ placement: 'top', content: 'Browse for multiple image/video files.' }"
+                                            v-bind:class="{ disabled: running[browser.id] }"
+                                            v-on:click="selectMediaFiles(browser, true)">
+                                            <div class="input-button">
+                                                <span class="icon"><i class="fas fa-folder-open"></i></span> Browse
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row" v-show="!browser._ && browser.it === 'slideshow'">
+                                        <div class="group"></div>
+                                        <div class="label label-si">Interval:</div>
+                                        <div class="field field-si"
+                                            v-tippy="{ placement: 'top', content: 'Time in seconds each slide is shown before advancing.' }">
+                                            <input type="text" v-model="browser.si" v-on:keyup="changed(browser)"
+                                                v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.si }"
+                                                v-bind:disabled="running[browser.id]">
+                                        </div>
+                                        <div class="unit">s</div>
+                                        <div class="label label-sf">Fade:</div>
+                                        <div class="field field-sf"
+                                            v-tippy="{ placement: 'top', content: 'Duration in seconds of the crossfade transition between slides.' }">
+                                            <input type="text" v-model="browser.sf" v-on:keyup="changed(browser)"
+                                                v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.sf }"
+                                                v-bind:disabled="running[browser.id]">
+                                        </div>
+                                        <div class="unit">s</div>
                                     </div>
                                     <div class="row" v-show="!browser._">
                                         <div class="group">PATCH:</div>
@@ -660,84 +778,39 @@
                                         </div>
                                     </div>
                                     <div class="row" v-show="!browser._">
-                                        <div class="group">OUTPUT 1:</div>
-                                        <div class="label label-output">Frameless:</div>
+                                        <div class="group">REFRESH:</div>
+                                        <div class="label">Auto-Refresh:</div>
                                         <div class="field"
-                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.D ? 'disable' : 'enable') + ' Frameless mode, where<br/>Web Content is rendered into a desktop window.' }">
-                                            <div class="toggle" v-on:click="toggle(browser, 'D', [ true, false ])">
-                                                <div class="toggle-option" v-bind:class="{ selected: browser.D === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
-                                                <div class="toggle-option" v-bind:class="{ selected: browser.D === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
+                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.ar ? 'disable' : 'enable') + ' automatic periodic page refresh.' }">
+                                            <div class="toggle" v-on:click="toggle(browser, 'ar', [ true, false ])">
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.ar === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.ar === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="row" v-show="!browser._ && browser.D">
-                                        <div class="group"></div>
-                                        <div class="sub-group">VIDEO:</div>
-                                        <div class="cluster" v-show="browser.D">
-                                            <div class="label label-position">Position:</div>
-                                            <div class="field field-x"
-                                                v-tippy="{ placement: 'top', content: 'X-Position of desktop window (0 is at left border)<br/>(absolute or relative to display).' }">
-                                                <input type="text" v-model="browser.x" v-on:keyup="changed(browser)"
-                                                    v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.x }"
+                                        <div class="cluster" v-show="browser.ar">
+                                            <div class="label">Interval:</div>
+                                            <div class="field field-framerate"
+                                                v-tippy="{ placement: 'top', content: 'Number of seconds between automatic page refreshes.' }">
+                                                <input type="text" v-model="browser.ai" v-on:keyup="changed(browser)"
+                                                    v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.ai }"
                                                     v-bind:disabled="running[browser.id]">
                                             </div>
-                                            <div class="sep">x</div>
-                                            <div class="field field-y"
-                                                v-tippy="{ placement: 'top', content: 'Y-Position of desktop window (0 is at top border)<br/>(absolute or relative to display).' }">
-                                                <input type="text" v-model="browser.y" v-on:keyup="changed(browser)"
-                                                    v-bind:class="{ disabled: running[browser.id], invalid: invalid[browser.id]?.y }"
-                                                    v-bind:disabled="running[browser.id]">
-                                            </div>
-                                            <div class="unit">px</div>
-                                            <div class="label">Display:</div>
-                                            <div class="field field-display"
-                                                v-tippy="{ placement: 'top', content: 'Selection of display<br/>for relative positioning.' }">
-                                                <div class="toggle" v-on:click="toggle(browser, 'd', displays.map((d) => d.num))">
-                                                    <div v-for="display in displays" v-bind:key="display.num"
-                                                        class="toggle-option toggle-display"
-                                                        v-show="browser.d === display.num">
-                                                        <div class="num">{{ display.num }}</div>
-                                                        <canvas class="display-icon"
-                                                            v-bind:ref="'display-icon-' + browser.id + '-' + display.num"
-                                                            v-bind:class="[ 'display-icon-' + display.num ]">
-                                                        </canvas>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="label">Pin:</div>
-                                            <div class="field field-pin"
-                                                v-tippy="{ placement: 'top', content: 'Click to ' + (browser.p ? 'disable' : 'enable') + ' pinning the desktop window to the top,<br/>i.e., above all other windows on the desktop.' }">
-                                                <div class="toggle" v-on:click="toggle(browser, 'p', [ true, false ])">
-                                                    <div class="toggle-option toggle-option-pin"   v-bind:class="{ selected: browser.p === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
-                                                    <div class="toggle-option toggle-option-nopin" v-bind:class="{ selected: browser.p === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
-                                                </div>
-                                            </div>
+                                            <div class="unit">s</div>
                                         </div>
-                                    </div>
-                                    <div class="row" v-show="!browser._ && browser.D">
-                                        <div class="group"></div>
-                                        <div class="sub-group">AUDIO:</div>
-                                        <div class="label label-device">Device:</div>
-                                        <div class="field field-device">
-                                            <vue-select class="select"
-                                                v-tippy="{ placement: 'top', content: 'Click to select<br/>audio output device.' }"
-                                                v-bind:options="audioDevices"
-                                                v-model="browser.A"
-                                                v-bind:placeholder="'(Default Audio Output Device)'"
-                                                v-bind:search-placeholder="'Type to search for audio device...'"
-                                                v-bind:searchable="true"
-                                                v-bind:close-on-select="true"
-                                                v-bind:empty-model-value="''"
-                                                v-on:update:model-value="changeOption(browser, 'A', $event)"
-                                                v-bind:class="{ disabled: running[browser.id] }"
-                                                v-bind:disabled="running[browser.id]"></vue-select>
+                                        <div class="label label-autostart">Auto-Start:</div>
+                                        <div class="field"
+                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.as ? 'disable' : 'enable') + ' automatic start of this instance<br/>when Vingester launches.' }">
+                                            <div class="toggle" v-on:click="toggle(browser, 'as', [ true, false ])">
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.as === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.as === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="row" v-show="!browser._">
-                                        <div class="group">OUTPUT 2:</div>
-                                        <div class="label label-output">Headless:</div>
+                                        <div class="group">NDI OUTPUT:</div>
+                                        <div class="label label-output">Enabled:</div>
                                         <div class="field"
-                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.N ? 'disable' : 'enable') + ' Headless mode, where Web Content is<br/>multicasted via NDI or passed to FFmpeg.' }">
+                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.N ? 'disable' : 'enable') + ' NDI output, where Web Content is<br/>multicasted via NDI or passed to FFmpeg.' }">
                                             <div class="toggle" v-on:click="toggle(browser, 'N', [ true, false ])">
                                                 <div class="toggle-option" v-bind:class="{ selected: browser.N === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
                                                 <div class="toggle-option" v-bind:class="{ selected: browser.N === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>

--- a/vingester-webui.html
+++ b/vingester-webui.html
@@ -1,0 +1,674 @@
+<!DOCTYPE html>
+<!--
+**  Vingester Web UI Dashboard
+**  Copyright (c) 2021-2025 Dr. Ralf S. Engelschall <rse@engelschall.com>
+**  Licensed under GPL 3.0 <https://spdx.org/licenses/GPL-3.0-only>
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Vingester Web UI</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #1a1a2e;
+            color: #e0e0e0;
+            min-height: 100vh;
+        }
+        header {
+            background: #16213e;
+            border-bottom: 2px solid #0f3460;
+            padding: 12px 24px;
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+        header h1 {
+            font-size: 1.4rem;
+            color: #e94560;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+        header .subtitle {
+            font-size: 0.75rem;
+            color: #888;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+        }
+        header .spacer { flex: 1; }
+        header .refresh-btn {
+            background: #0f3460;
+            border: 1px solid #e94560;
+            color: #e94560;
+            padding: 6px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.85rem;
+            letter-spacing: 1px;
+        }
+        header .refresh-btn:hover { background: #e94560; color: #fff; }
+        .tabs {
+            display: flex;
+            background: #16213e;
+            border-bottom: 1px solid #0f3460;
+            padding: 0 24px;
+        }
+        .tab {
+            padding: 10px 20px;
+            cursor: pointer;
+            font-size: 0.85rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: #888;
+            border-bottom: 3px solid transparent;
+            transition: all 0.2s;
+        }
+        .tab:hover { color: #e0e0e0; }
+        .tab.active { color: #e94560; border-bottom-color: #e94560; }
+        .container { padding: 24px; max-width: 1200px; margin: 0 auto; }
+        .panel { display: none; }
+        .panel.active { display: block; }
+        .section-title {
+            font-size: 0.75rem;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            color: #888;
+            margin-bottom: 12px;
+            padding-bottom: 6px;
+            border-bottom: 1px solid #0f3460;
+        }
+        .global-actions {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 24px;
+            flex-wrap: wrap;
+        }
+        .btn {
+            padding: 8px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.85rem;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            border: 1px solid;
+            transition: all 0.2s;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .btn-start   { border-color: #27ae60; color: #27ae60; background: transparent; }
+        .btn-start:hover  { background: #27ae60; color: #fff; }
+        .btn-stop    { border-color: #e74c3c; color: #e74c3c; background: transparent; }
+        .btn-stop:hover   { background: #e74c3c; color: #fff; }
+        .btn-reload  { border-color: #3498db; color: #3498db; background: transparent; }
+        .btn-reload:hover { background: #3498db; color: #fff; }
+        .btn-delete  { border-color: #e74c3c; color: #e74c3c; background: transparent; }
+        .btn-delete:hover { background: #e74c3c; color: #fff; }
+        .btn-upload  { border-color: #9b59b6; color: #9b59b6; background: transparent; }
+        .btn-upload:hover { background: #9b59b6; color: #fff; }
+        .btn:disabled, .btn.disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
+        .instances-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+            gap: 16px;
+        }
+        .instance-card {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 8px;
+            padding: 16px;
+            position: relative;
+            transition: border-color 0.2s;
+        }
+        .instance-card.running  { border-color: #27ae60; }
+        .instance-card.stopped  { border-color: #e74c3c; }
+        .instance-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 10px;
+        }
+        .instance-status {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: #e74c3c;
+            flex-shrink: 0;
+        }
+        .instance-status.running { background: #27ae60; animation: pulse 2s infinite; }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+        .instance-title {
+            font-size: 0.95rem;
+            font-weight: 600;
+            color: #e0e0e0;
+            flex: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .instance-info {
+            font-size: 0.75rem;
+            color: #888;
+            margin-bottom: 10px;
+        }
+        .instance-url {
+            font-size: 0.7rem;
+            color: #3498db;
+            word-break: break-all;
+            margin-bottom: 10px;
+            font-family: monospace;
+        }
+        .instance-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 12px;
+        }
+        .badge {
+            font-size: 0.65rem;
+            padding: 2px 8px;
+            border-radius: 12px;
+            background: #0f3460;
+            color: #888;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+        }
+        .badge.ndi     { background: #1a4a2e; color: #27ae60; }
+        .badge.autoref { background: #1a2a4e; color: #3498db; }
+        .badge.autostr { background: #2a1a4e; color: #9b59b6; }
+        .instance-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+        .instance-actions .btn { padding: 5px 12px; font-size: 0.75rem; }
+        .loading {
+            text-align: center;
+            padding: 40px;
+            color: #888;
+            font-size: 0.9rem;
+        }
+        .error-msg {
+            background: #2d1515;
+            border: 1px solid #e74c3c;
+            border-radius: 6px;
+            padding: 12px 16px;
+            color: #e74c3c;
+            margin-bottom: 16px;
+            font-size: 0.85rem;
+        }
+        .empty-msg {
+            text-align: center;
+            padding: 40px;
+            color: #555;
+            font-size: 0.9rem;
+        }
+        /* Media Manager */
+        .upload-zone {
+            border: 2px dashed #0f3460;
+            border-radius: 8px;
+            padding: 32px;
+            text-align: center;
+            margin-bottom: 24px;
+            cursor: pointer;
+            transition: border-color 0.2s;
+        }
+        .upload-zone:hover, .upload-zone.dragover { border-color: #9b59b6; }
+        .upload-zone input[type=file] { display: none; }
+        .upload-zone .upload-icon { font-size: 2rem; color: #9b59b6; margin-bottom: 8px; }
+        .upload-zone .upload-text { color: #888; font-size: 0.9rem; }
+        .upload-zone .upload-hint { color: #555; font-size: 0.75rem; margin-top: 4px; }
+        .upload-progress {
+            background: #0f3460;
+            border-radius: 4px;
+            height: 4px;
+            margin-bottom: 16px;
+            display: none;
+        }
+        .upload-progress-bar {
+            height: 100%;
+            background: #9b59b6;
+            border-radius: 4px;
+            width: 0;
+            transition: width 0.3s;
+        }
+        .media-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 12px;
+        }
+        .media-item {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 8px;
+            overflow: hidden;
+            transition: border-color 0.2s;
+        }
+        .media-item:hover { border-color: #9b59b6; }
+        .media-thumb {
+            width: 100%;
+            height: 120px;
+            object-fit: cover;
+            display: block;
+            background: #0f3460;
+        }
+        .media-thumb-video {
+            width: 100%;
+            height: 120px;
+            object-fit: cover;
+            display: block;
+            background: #0f3460;
+        }
+        .media-info {
+            padding: 8px 10px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .media-name {
+            flex: 1;
+            font-size: 0.75rem;
+            color: #e0e0e0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .media-size { font-size: 0.65rem; color: #555; }
+        .media-delete {
+            background: none;
+            border: none;
+            color: #e74c3c;
+            cursor: pointer;
+            font-size: 0.85rem;
+            padding: 2px 4px;
+            border-radius: 3px;
+        }
+        .media-delete:hover { background: #2d1515; }
+        /* Toast */
+        .toast-container {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            z-index: 1000;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .toast {
+            background: #16213e;
+            border: 1px solid #0f3460;
+            border-radius: 6px;
+            padding: 10px 16px;
+            font-size: 0.85rem;
+            color: #e0e0e0;
+            max-width: 320px;
+            animation: slideIn 0.3s ease;
+        }
+        .toast.success { border-color: #27ae60; color: #27ae60; }
+        .toast.error   { border-color: #e74c3c; color: #e74c3c; }
+        @keyframes slideIn {
+            from { transform: translateX(100%); opacity: 0; }
+            to   { transform: translateX(0);   opacity: 1; }
+        }
+        .status-bar {
+            background: #16213e;
+            border-top: 1px solid #0f3460;
+            padding: 6px 24px;
+            font-size: 0.7rem;
+            color: #555;
+            display: flex;
+            gap: 16px;
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+        }
+        .status-bar span { color: #888; }
+    </style>
+</head>
+<body>
+
+<header>
+    <div>
+        <h1>&#9658; Vingester</h1>
+        <div class="subtitle">Web UI Dashboard</div>
+    </div>
+    <div class="spacer"></div>
+    <button class="refresh-btn" onclick="refreshAll()">&#8635; Refresh</button>
+</header>
+
+<div class="tabs">
+    <div class="tab active" data-panel="instances" onclick="switchTab('instances', this)">Instances</div>
+    <div class="tab" data-panel="media" onclick="switchTab('media', this)">Media Manager</div>
+</div>
+
+<div class="container">
+    <div id="panel-instances" class="panel active">
+        <div id="error-instances" class="error-msg" style="display:none"></div>
+        <div class="section-title">Global Controls</div>
+        <div class="global-actions">
+            <button class="btn btn-start"  onclick="cmdAll('start')">&#9654; Start All</button>
+            <button class="btn btn-stop"   onclick="cmdAll('stop')">&#9646;&#9646; Stop All</button>
+            <button class="btn btn-reload" onclick="cmdAll('reload')">&#8635; Reload All</button>
+        </div>
+        <div class="section-title">Browser Instances</div>
+        <div id="instances-loading" class="loading">Loading instances&hellip;</div>
+        <div id="instances-empty"  class="empty-msg" style="display:none">No browser instances configured. Use the Vingester desktop app to add instances.</div>
+        <div id="instances-grid"   class="instances-grid" style="display:none"></div>
+    </div>
+
+    <div id="panel-media" class="panel">
+        <div id="error-media" class="error-msg" style="display:none"></div>
+        <div class="section-title">Upload Media</div>
+        <div class="upload-zone" id="upload-zone" onclick="document.getElementById('file-input').click()"
+             ondragover="onDragOver(event)" ondragleave="onDragLeave(event)" ondrop="onDrop(event)">
+            <input type="file" id="file-input" multiple accept="image/*,video/*" onchange="uploadFiles(this.files)"/>
+            <div class="upload-icon">&#8679;</div>
+            <div class="upload-text">Click to upload or drag &amp; drop files here</div>
+            <div class="upload-hint">Allowed: PNG, JPG, GIF, WEBP, BMP, SVG, MP4, WEBM, OGG, MOV (max 500 MB)</div>
+        </div>
+        <div class="upload-progress" id="upload-progress">
+            <div class="upload-progress-bar" id="upload-progress-bar"></div>
+        </div>
+        <div class="section-title">Media Library</div>
+        <div id="media-loading" class="loading">Loading media&hellip;</div>
+        <div id="media-empty"  class="empty-msg" style="display:none">No media files uploaded yet.</div>
+        <div id="media-grid"   class="media-grid" style="display:none"></div>
+    </div>
+</div>
+
+<div class="status-bar">
+    <span id="status-count">0 instances</span>
+    <span id="status-running">0 running</span>
+    <span id="status-time"></span>
+</div>
+
+<div class="toast-container" id="toast-container"></div>
+
+<script>
+(function () {
+    const BASE = window.location.origin
+
+    function switchTab (panel, el) {
+        document.querySelectorAll(".tab").forEach(t => t.classList.remove("active"))
+        document.querySelectorAll(".panel").forEach(p => p.classList.remove("active"))
+        el.classList.add("active")
+        document.getElementById("panel-" + panel).classList.add("active")
+        if (panel === "media") loadMedia()
+        if (panel === "instances") loadInstances()
+    }
+    window.switchTab = switchTab
+
+    function toast (msg, type) {
+        const c = document.getElementById("toast-container")
+        const t = document.createElement("div")
+        t.className = "toast " + (type || "")
+        t.textContent = msg
+        c.appendChild(t)
+        setTimeout(() => { t.remove() }, 3500)
+    }
+
+    async function apiFetch (path, options) {
+        try {
+            const res = await fetch(BASE + path, options || {})
+            const text = await res.text()
+            let data
+            try { data = JSON.parse(text) } catch (e) { data = text }
+            if (!res.ok) throw new Error(data?.message || data || "HTTP " + res.status)
+            return { ok: true, data }
+        } catch (err) {
+            return { ok: false, error: err.message }
+        }
+    }
+
+    function formatSize (bytes) {
+        if (bytes < 1024)        return bytes + " B"
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB"
+        return (bytes / 1024 / 1024).toFixed(1) + " MB"
+    }
+
+    /* ---- INSTANCES ---- */
+
+    async function loadInstances () {
+        const grid    = document.getElementById("instances-grid")
+        const loading = document.getElementById("instances-loading")
+        const empty   = document.getElementById("instances-empty")
+        const errBox  = document.getElementById("error-instances")
+
+        loading.style.display = "block"
+        grid.style.display    = "none"
+        empty.style.display   = "none"
+        errBox.style.display  = "none"
+
+        const result = await apiFetch("/api/instances")
+        loading.style.display = "none"
+
+        if (!result.ok) {
+            errBox.textContent = "Failed to load instances: " + result.error
+            errBox.style.display = "block"
+            return
+        }
+
+        const instances = result.data
+        const running   = instances.filter(i => i.running).length
+
+        document.getElementById("status-count").textContent   = instances.length + " instance" + (instances.length !== 1 ? "s" : "")
+        document.getElementById("status-running").textContent = running + " running"
+        document.getElementById("status-time").textContent    = "Updated: " + new Date().toLocaleTimeString()
+
+        if (instances.length === 0) {
+            empty.style.display = "block"
+            return
+        }
+
+        grid.innerHTML = ""
+        for (const inst of instances) {
+            const card = document.createElement("div")
+            card.className = "instance-card " + (inst.running ? "running" : "stopped")
+            card.dataset.id = inst.id
+
+            const urlDisplay = inst.inputType !== "url"
+                ? "(" + inst.inputType + ")"
+                : (inst.url || "(no URL)")
+
+            const badges = []
+            if (inst.ndi)         badges.push('<span class="badge ndi">NDI</span>')
+            if (inst.autoRefresh) badges.push('<span class="badge autoref">Auto-Refresh ' + inst.autoRefreshInterval + 's</span>')
+            if (inst.autoStart)   badges.push('<span class="badge autostr">Auto-Start</span>')
+
+            card.innerHTML = `
+                <div class="instance-header">
+                    <div class="instance-status ${inst.running ? "running" : ""}"></div>
+                    <div class="instance-title">${escHtml(inst.title)}</div>
+                </div>
+                ${inst.info ? '<div class="instance-info">' + escHtml(inst.info) + '</div>' : ''}
+                <div class="instance-url">${escHtml(urlDisplay)}</div>
+                <div class="instance-meta">
+                    <span class="badge">${inst.width}x${inst.height}</span>
+                    <span class="badge">${inst.fps} fps</span>
+                    ${badges.join("")}
+                </div>
+                <div class="instance-actions">
+                    ${!inst.running ? '<button class="btn btn-start"  onclick="cmdInstance(\'' + inst.id + '\',\'start\')">&#9654; Start</button>' : ''}
+                    ${inst.running  ? '<button class="btn btn-stop"   onclick="cmdInstance(\'' + inst.id + '\',\'stop\')">&#9646;&#9646; Stop</button>'  : ''}
+                    ${inst.running  ? '<button class="btn btn-reload" onclick="cmdInstance(\'' + inst.id + '\',\'reload\')">&#8635; Reload</button>' : ''}
+                </div>
+            `
+            grid.appendChild(card)
+        }
+        grid.style.display = "grid"
+    }
+    window.loadInstances = loadInstances
+
+    async function cmdInstance (id, command) {
+        const result = await apiFetch("/api/instances/" + id + "/" + command, { method: "POST" })
+        if (result.ok) {
+            toast(command.charAt(0).toUpperCase() + command.slice(1) + " sent", "success")
+            setTimeout(loadInstances, 500)
+        } else {
+            toast("Failed: " + result.error, "error")
+        }
+    }
+    window.cmdInstance = cmdInstance
+
+    async function cmdAll (command) {
+        const result = await apiFetch("/api/all/" + command, { method: "POST" })
+        if (result.ok) {
+            toast(command.charAt(0).toUpperCase() + command.slice(1) + " all sent", "success")
+            setTimeout(loadInstances, 700)
+        } else {
+            toast("Failed: " + result.error, "error")
+        }
+    }
+    window.cmdAll = cmdAll
+
+    /* ---- MEDIA ---- */
+
+    async function loadMedia () {
+        const grid    = document.getElementById("media-grid")
+        const loading = document.getElementById("media-loading")
+        const empty   = document.getElementById("media-empty")
+        const errBox  = document.getElementById("error-media")
+
+        loading.style.display = "block"
+        grid.style.display    = "none"
+        empty.style.display   = "none"
+        errBox.style.display  = "none"
+
+        const result = await apiFetch("/api/media")
+        loading.style.display = "none"
+
+        if (!result.ok) {
+            errBox.textContent = "Failed to load media: " + result.error
+            errBox.style.display = "block"
+            return
+        }
+
+        const files = result.data
+        if (files.length === 0) {
+            empty.style.display = "block"
+            return
+        }
+
+        grid.innerHTML = ""
+        for (const file of files) {
+            const item = document.createElement("div")
+            item.className = "media-item"
+            const mediaEl = file.type === "image"
+                ? `<img class="media-thumb" src="${BASE + file.url}" loading="lazy" alt="${escHtml(file.name)}"/>`
+                : `<video class="media-thumb-video" src="${BASE + file.url}" muted preload="metadata"></video>`
+            item.innerHTML = `
+                ${mediaEl}
+                <div class="media-info">
+                    <span class="media-name" title="${escHtml(file.name)}">${escHtml(file.name)}</span>
+                    <span class="media-size">${formatSize(file.size)}</span>
+                    <button class="media-delete" title="Delete file" onclick="deleteMedia('${escHtml(file.name)}')">&#10005;</button>
+                </div>
+            `
+            grid.appendChild(item)
+        }
+        grid.style.display = "grid"
+    }
+    window.loadMedia = loadMedia
+
+    async function deleteMedia (name) {
+        if (!confirm("Delete '" + name + "'?")) return
+        const result = await apiFetch("/api/media/" + encodeURIComponent(name), { method: "DELETE" })
+        if (result.ok) {
+            toast("Deleted: " + name, "success")
+            loadMedia()
+        } else {
+            toast("Delete failed: " + result.error, "error")
+        }
+    }
+    window.deleteMedia = deleteMedia
+
+    function onDragOver (ev) {
+        ev.preventDefault()
+        document.getElementById("upload-zone").classList.add("dragover")
+    }
+    function onDragLeave () {
+        document.getElementById("upload-zone").classList.remove("dragover")
+    }
+    function onDrop (ev) {
+        ev.preventDefault()
+        document.getElementById("upload-zone").classList.remove("dragover")
+        if (ev.dataTransfer.files.length > 0)
+            uploadFiles(ev.dataTransfer.files)
+    }
+    window.onDragOver = onDragOver
+    window.onDragLeave = onDragLeave
+    window.onDrop = onDrop
+
+    async function uploadFiles (fileList) {
+        const progressEl    = document.getElementById("upload-progress")
+        const progressBarEl = document.getElementById("upload-progress-bar")
+
+        progressEl.style.display = "block"
+        progressBarEl.style.width = "0%"
+
+        const files  = Array.from(fileList)
+        let uploaded = 0
+        for (const file of files) {
+            const form = new FormData()
+            form.append("file", file)
+            const result = await apiFetch("/api/media/upload", { method: "POST", body: form })
+            if (result.ok) {
+                uploaded++
+                toast("Uploaded: " + file.name, "success")
+            } else {
+                toast("Upload failed (" + file.name + "): " + result.error, "error")
+            }
+            progressBarEl.style.width = Math.round((uploaded / files.length) * 100) + "%"
+        }
+
+        setTimeout(() => {
+            progressEl.style.display  = "none"
+            progressBarEl.style.width = "0%"
+        }, 1500)
+
+        if (uploaded > 0) loadMedia()
+    }
+    window.uploadFiles = uploadFiles
+
+    /* ---- HELPERS ---- */
+
+    function escHtml (str) {
+        return String(str)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+    }
+
+    function refreshAll () {
+        const active = document.querySelector(".tab.active")
+        if (active?.dataset?.panel === "media") loadMedia()
+        else loadInstances()
+    }
+    window.refreshAll = refreshAll
+
+    /* ---- AUTO-REFRESH ---- */
+    let autoRefreshInterval = null
+    function startAutoRefresh () {
+        autoRefreshInterval = setInterval(() => {
+            const active = document.querySelector(".tab.active")
+            if (active?.dataset?.panel === "instances") loadInstances()
+        }, 5000)
+    }
+
+    /* ---- INIT ---- */
+    loadInstances()
+    startAutoRefresh()
+    setInterval(() => {
+        document.getElementById("status-time").textContent = "Updated: " + new Date().toLocaleTimeString()
+    }, 1000)
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
…, Web UI, Windows service, remove frameless Output1

- Remove Output1 (frameless window) entirely; NDI/FFmpeg is the only output mode
  - Legacy Output1 fields in old YAML configs are silently ignored on import
- Add per-instance AutoRefreshEnabled + AutoRefreshInterval settings (timer-based reload)
- Add InstanceAutoStart per-instance flag (start on program launch, independent of --autostart)
- Add InputType field: url (default), image, video, slideshow
  - Image/video/slideshow inputs generate an HTML page on-the-fly and load it via file://
  - Slideshows use CSS opacity transitions with configurable interval and fade duration
- Add Web UI dashboard server (port 7212, toggle in control UI)
  - Serves vingester-webui.html with live instance status, start/stop/reload controls
  - Media Manager: upload, list and delete image/video files via drag-and-drop
  - REST endpoints: /api/instances, /api/all/{cmd}, /api/media, /media/{file}
  - File-type enforcement: only images and videos accepted (max 500 MB)
- Add installer/install-service.js for Windows service install/uninstall via NSSM
  - Configures auto-start on boot, crash recovery, log rotation
- Fix ipcMain memory leak: browser-worker-stopped now uses ipcMain.once()
- Fix auto-refresh timer: properly cleared on stop, recreated on reconfigure
- Fix generated HTML cleanup: temp files deleted when instance stops
- Comprehensive README rewrite: CLI flags, all config fields, input types, build guide, Windows/Linux/macOS service instructions, settings compatibility notes

https://claude.ai/code/session_01DQ7MLszT4gATRbmoo9NyGA