### PR TITLE
Add Syphon output sink (macOS, opt-in)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
         "@hapi/boom":                    "9.1.4",
         "hapi-plugin-header":            "1.1.4"
     },
+    "optionalDependencies": {
+        "node-syphon":                   "1.5.0"
+    },
     "main":                              "vingester-main.js",
     "upd":                               [ "!execa", "!got", "!dsig" ],
     "build": {
@@ -76,7 +79,8 @@
         "asar":                          true,
         "asarUnpack":                    [ "node_modules/@rse/ffmpeg/**",
                                            "node_modules/grandiose/**",
-                                           "node_modules/@discordjs/opus/**" ],
+                                           "node_modules/@discordjs/opus/**",
+                                           "node_modules/node-syphon/**" ],
         "removePackageScripts":          true,
         "compression":                   "normal",
         "directories": {

--- a/vingester-browser-worker.js
+++ b/vingester-browser-worker.js
@@ -256,7 +256,10 @@ class BrowserWorker {
 
         /*  send video frame  */
         if (this.cfg.N) {
-            /*  normalize endianness once for any sink that wants BGRA  */
+            /*  normalize endianness once for BGRA-consuming sinks (NDI, Syphon).
+                FFmpeg is intentionally excluded: it receives a JPEG below
+                (re-encoded by Electron's nativeImage) and handles pixel format
+                internally, so the raw buffer endianness is irrelevant to it.  */
             if ((this.cfg.n || this.syphonServer !== null) && os.endianness() === "BE")
                 util.ImageBufferAdjustment.ARGBtoBGRA(buffer)
 

--- a/vingester-browser-worker.js
+++ b/vingester-browser-worker.js
@@ -14,6 +14,16 @@ const pcmconvert       = require("pcm-convert")
 const ebml             = require("ebml")
 const Opus             = require("@discordjs/opus")
 
+/*  Syphon is an optional macOS-only dependency (zero-network local
+    GPU video routing to Resolume / OBS / VDMX / etc.)  */
+let SyphonMetalServer = null
+if (process.platform === "darwin") {
+    try {
+        SyphonMetalServer = require("node-syphon").SyphonMetalServer
+    }
+    catch (err) { /* node-syphon not installed on this platform */ }
+}
+
 /*  require own modules  */
 const util             = require("./vingester-util.js")
 const FFmpeg           = require("./vingester-ffmpeg.js")
@@ -42,6 +52,7 @@ class BrowserWorker {
         this.timeStart       = (BigInt(Date.now()) * BigInt(1e6) - process.hrtime.bigint())
         this.ndiSender       = null
         this.ndiTimer        = null
+        this.syphonServer    = null
         this.ffmpeg          = null
         this.opusEncoder     = null
         this.burst1          = null
@@ -99,6 +110,18 @@ class BrowserWorker {
                     electron.ipcRenderer.send("tally",
                         { status: this.ndiStatus, connections: conns, id: this.id })
                 }, 1 * 500)
+            }
+            if (this.cfg.s && SyphonMetalServer !== null) {
+                /*  start a Syphon (macOS GPU sharing) server to publish frames
+                    locally with zero network/encoder overhead  */
+                try {
+                    this.syphonServer = new SyphonMetalServer(title)
+                    this.log.info(`Syphon server started: "${title}"`)
+                }
+                catch (err) {
+                    this.log.error(`failed to start Syphon server: ${err}`)
+                    this.syphonServer = null
+                }
             }
             if (this.cfg.m) {
                 this.ffmpeg = new FFmpeg({
@@ -175,6 +198,13 @@ class BrowserWorker {
         if (this.ndiSender !== null)
             await this.ndiSender.destroy()
 
+        /*  destroy Syphon server  */
+        if (this.syphonServer !== null) {
+            try { this.syphonServer.dispose() }
+            catch (err) { this.log.error(`Syphon dispose error: ${err}`) }
+            this.syphonServer = null
+        }
+
         /*  destroy FFmpeg sender  */
         if (this.ffmpeg !== null)
             await this.ffmpeg.stop()
@@ -226,13 +256,30 @@ class BrowserWorker {
 
         /*  send video frame  */
         if (this.cfg.N) {
-            if (this.cfg.n) {
-                /*  convert from ARGB (Electron/Chromium on big endian CPU)
-                    to BGRA (supported input of NDI SDK). On little endian
-                    CPU the input is already BGRA.  */
-                if (os.endianness() === "BE")
-                    util.ImageBufferAdjustment.ARGBtoBGRA(buffer)
+            /*  normalize endianness once for any sink that wants BGRA  */
+            if ((this.cfg.n || this.syphonServer !== null) && os.endianness() === "BE")
+                util.ImageBufferAdjustment.ARGBtoBGRA(buffer)
 
+            /*  publish to Syphon BEFORE the NDI BGRA->BGRX in-place mutation
+                so Syphon receives the original alpha-preserving BGRA frame.
+                node-syphon's publishImageData requires Uint8ClampedArray
+                (not Node Buffer); wrap as a zero-copy view.  */
+            if (this.syphonServer !== null) {
+                try {
+                    const pixels = new Uint8ClampedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+                    this.syphonServer.publishImageData(
+                        pixels,
+                        { x: 0, y: 0, width: size.width, height: size.height },
+                        { width: size.width, height: size.height },
+                        false
+                    )
+                }
+                catch (err) {
+                    this.log.error(`Syphon publish error: ${err}`)
+                }
+            }
+
+            if (this.cfg.n) {
                 /*  optionally convert from BGRA to BGRX (no alpha channel)  */
                 let fourCC = grandiose.FOURCC_BGRA
                 if (!this.cfg.v) {

--- a/vingester-browser.js
+++ b/vingester-browser.js
@@ -17,6 +17,19 @@ const bluebird    = require("bluebird")
 const util        = require("./vingester-util.js")
 const pkg         = require("./package.json")
 
+/*  Syphon availability (optional, macOS-only) — used to gate the `s`
+    sub-sink in valid() so configs imported on unsupported platforms
+    are correctly flagged as invalid rather than silently producing
+    no output  */
+let syphonAvailable = false
+if (process.platform === "darwin") {
+    try {
+        require("node-syphon")
+        syphonAvailable = true
+    }
+    catch (err) { /* node-syphon is not installed on this platform */ }
+}
+
 /*  browser abstraction  */
 module.exports = class Browser {
     /*  create new browser  */
@@ -151,7 +164,7 @@ module.exports = class Browser {
     valid () {
         return (
             (this.cfg.D || this.cfg.N)
-            && (!this.cfg.N || (this.cfg.N && (this.cfg.n || this.cfg.m || this.cfg.s)))
+            && (!this.cfg.N || (this.cfg.N && (this.cfg.n || this.cfg.m || (this.cfg.s && syphonAvailable))))
             && this.cfg.t !== ""
             && this.cfg.u !== ""
         )

--- a/vingester-browser.js
+++ b/vingester-browser.js
@@ -151,7 +151,7 @@ module.exports = class Browser {
     valid () {
         return (
             (this.cfg.D || this.cfg.N)
-            && (!this.cfg.N || (this.cfg.N && (this.cfg.n || this.cfg.m)))
+            && (!this.cfg.N || (this.cfg.N && (this.cfg.n || this.cfg.m || this.cfg.s)))
             && this.cfg.t !== ""
             && this.cfg.u !== ""
         )

--- a/vingester-control.html
+++ b/vingester-control.html
@@ -871,6 +871,18 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="row" v-show="!browser._ && browser.N && support.syphon">
+                                        <div class="group"></div>
+                                        <div class="sub-group"></div>
+                                        <div class="label label-kind">Syphon&trade;:</div>
+                                        <div class="field"
+                                            v-tippy="{ placement: 'top', content: 'Click to ' + (browser.s ? 'disable' : 'enable') + ' Syphon sink (macOS GPU sharing for local apps like Resolume, OBS, VDMX).' }">
+                                            <div class="toggle" v-on:click="toggle(browser, 's', [ true, false ])">
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.s === true  }"><span class="icon"><i class="fas fa-check-circle"></i></span> YES</div>
+                                                <div class="toggle-option" v-bind:class="{ selected: browser.s === false }"><span class="icon"><i class="fas fa-times-circle"></i></span> NO</div>
+                                            </div>
+                                        </div>
+                                    </div>
                                     <div class="row" v-show="!browser._ && browser.N">
                                         <div class="group"></div>
                                         <div class="sub-group"></div>

--- a/vingester-control.js
+++ b/vingester-control.js
@@ -333,7 +333,7 @@ const app = Vue.createApp({
             if (browser.d >= this.displays.length)
                 browser.d = (this.displays.length - 1)
             if (   (browser.D || browser.N)
-                && (!browser.N || (browser.N && (browser.n || browser.m || browser.s)))
+                && (!browser.N || (browser.N && (browser.n || browser.m || (browser.s && this.support.syphon))))
                 && browser.t !== "" && browser.u !== "")
                 delete this.invalid[browser.id].GLOBAL
             else

--- a/vingester-control.js
+++ b/vingester-control.js
@@ -333,7 +333,7 @@ const app = Vue.createApp({
             if (browser.d >= this.displays.length)
                 browser.d = (this.displays.length - 1)
             if (   (browser.D || browser.N)
-                && (!browser.N || (browser.N && (browser.n || browser.m)))
+                && (!browser.N || (browser.N && (browser.n || browser.m || browser.s)))
                 && browser.t !== "" && browser.u !== "")
                 delete this.invalid[browser.id].GLOBAL
             else

--- a/vingester-main.js
+++ b/vingester-main.js
@@ -54,9 +54,18 @@ const version = {
     ffmpeg:    FFmpeg.info.version,
     vuejs:     pkg.dependencies.vue
 }
+let syphonAvailable = false
+if (process.platform === "darwin") {
+    try {
+        require("node-syphon")
+        syphonAvailable = true
+    }
+    catch (err) { /* node-syphon is an optional macOS-only dependency */ }
+}
 const support = {
     ndi:       grandiose.isSupportedCPU(),
-    srt:       FFmpeg.info.protocols?.srt?.input === true
+    srt:       FFmpeg.info.protocols?.srt?.input === true,
+    syphon:    syphonAvailable
 }
 electron.ipcMain.handle("version", (ev) => { return version })
 electron.ipcMain.handle("support", (ev) => { return support })
@@ -67,6 +76,7 @@ log.info(`using V8: ${version.v8}`)
 log.info(`using Node.js: ${version.node}`)
 log.info(`using NDI: ${version.ndi} (supported by CPU: ${support.ndi ? "yes" : "no"})`)
 log.info(`using FFmpeg: ${version.ffmpeg}`)
+log.info(`using Syphon: ${support.syphon ? "yes (macOS)" : "no"}`)
 log.info(`using Vue: ${version.vuejs}`)
 
 /*  support particular profiles  */
@@ -362,6 +372,7 @@ electron.app.on("ready", async () => {
         { iname: "v", itype: "boolean", def: true,          etype: "boolean", ename: "Output2SinkNDIAlpha" },
         { iname: "l", itype: "boolean", def: false,         etype: "boolean", ename: "Output2SinkNDITallyReload" },
         { iname: "m", itype: "boolean", def: false,         etype: "boolean", ename: "Output2SinkFFmpegEnabled" },
+        { iname: "s", itype: "boolean", def: false,         etype: "boolean", ename: "Output2SinkSyphonEnabled" },
         { iname: "R", itype: "string",  def: "vbr",         etype: "string",  ename: "Output2SinkFFmpegMode" },
         { iname: "F", itype: "string",  def: "matroska",    etype: "string",  ename: "Output2SinkFFmpegFormat" },
         { iname: "M", itype: "string",  def: "",            etype: "string",  ename: "Output2SinkFFmpegOptions" },


### PR DESCRIPTION
Adds a third Output 2 sink alongside **NDI** and **FFmpeg**: a macOS-only [Syphon](https://syphon.info/) server that publishes captured Web frames as a Syphon source via [`node-syphon`](https://github.com/benoitlahoz/node-syphon). Other macOS apps on the same machine — **Resolume**, **OBS** (with the Syphon plugin), **VDMX**, **TouchDesigner**, **MadMapper** — can then consume the video locally without going through the NDI encoder + network stack.

## Why add a Syphon sink

For local same-Mac pipelines into VJ/streaming software, Syphon is the right primitive:

| | Syphon | NDI |
|---|---|---|
| Transport | Shared GPU surface (IOSurface + Mach ports) | CPU readback → SpeedHQ encode → socket → decode |
| Localhost latency | <5 ms | 1–3 frames |
| CPU cost | ~0% | NDI's encoder isn't free at high frame rates |
| Reach | Same Mac only | Network-wide, cross-platform |

NDI keeps doing what it does best (cross-machine routing). This just gives macOS users a much faster local option.

## Cross-platform philosophy: opt-in only, no impact elsewhere

I'm aware the project values tri-platform parity. This PR is structured so it cleanly degrades on Windows and Linux:

- `node-syphon` is in **`optionalDependencies`**, not `dependencies` — `npm install` skips it cleanly on Win/Linux.
- A runtime `support.syphon` flag is `true` only on macOS *and* only when the dep loaded — gated by `process.platform === "darwin"` plus a try/`require`.
- The new "Syphon" UI row is rendered only when `support.syphon` is true (`v-show="… && support.syphon"`), so the control window on Win/Linux is byte-identical to before.
- `valid()` (main process) and the renderer-side mirror only count `cfg.s` as a valid Output 2 sub-sink when Syphon is actually available — so a YAML config imported on an unsupported host with `Output2SinkSyphonEnabled: true` is correctly flagged invalid rather than silently dropping every frame.

A natural counterpart on Windows is **[Spout](https://spout.zeal.co/)**, which has the same role and is also wrapped by some Node bindings. Happy to look at adding Spout in a follow-up PR if you'd like; I kept this PR macOS-only to keep the surface small and reviewable, and because Syphon is what I have a working setup for.

## Implementation details

- New config field `s` / `Output2SinkSyphonEnabled`, parallel to `n` (NDI) and `m` (FFmpeg).
- `vingester-browser-worker.js`: try-`require`s `SyphonMetalServer` once at module load on darwin; creates one server per worker named after the browser title; publishes each captured frame's BGRA buffer via `publishImageData` (wrapped as `Uint8ClampedArray` — that's what `node-syphon` requires); disposes in `stop()`. The publish happens **before** the existing NDI in-place `BGRA→BGRX` mutation so Syphon receives the original alpha-preserving frame.
- `vingester-main.js`: detects `node-syphon` availability and exposes `support.syphon` to the renderer via the existing `support` IPC handle; logs Syphon availability at startup alongside NDI/FFmpeg.
- `vingester-control.html`: new SINK row with a YES/NO toggle, gated on `support.syphon`.
- The existing `cfg.N` master toggle still gates the entire Output 2 block; Syphon is just one of three checkbox-level sub-sinks underneath it.
- An inline comment in the worker explains why FFmpeg is intentionally excluded from the BGRA endianness normalization (it gets a JPEG from `nativeImage.toJPEG()` and handles pixel format itself).

## Diff size

| File | +/− |
|---|---|
| `package.json` | +5 −1 |
| `vingester-main.js` | +12 −1 |
| `vingester-browser.js` | +14 −1 |
| `vingester-browser-worker.js` | +56 −6 |
| `vingester-control.js` | +1 −1 |
| `vingester-control.html` | +12 |
| **Total** | **+100 −10** |

## License

`node-syphon` is GPL-3.0+, compatible with Vingester's GPL-3.0-only.

## Verified locally

- macOS 26.4 / Apple Silicon: `cfg.s=true` flows from YAML → main → worker; `node-syphon` loads inside the Electron 18 renderer; `SyphonMetalServer` constructs with the correct name and a real `info.v002.Syphon.<UUID>` identifier; frames publish at the configured FPS without errors; clean shutdown on stop.
- Receiver-app smoke: works as a Syphon source for typical receivers on the same machine.
- Bundling: `node_modules/node-syphon/**` is `asarUnpack`ed so `syphon.node` and `Syphon.framework` (universal2) are both extracted next to the runtime.

## Known follow-ups (not in this PR)

- A symmetric per-frame error rate-limit for **all three sinks** (NDI / FFmpeg / Syphon currently each `log.error` per failed frame, which can flood at 30+ fps if a sink gets stuck). This is a pre-existing pattern; happy to send a separate PR if you'd like it.
- A Windows Spout equivalent for cross-platform parity.